### PR TITLE
Add airport code format toggle

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -324,6 +324,7 @@ HideCols = [
 
 // get flight route from routeApi service default setting (toggle via settings checkbox)
 // useRouteAPI = false;
+// useIataAirportCodes = true; // use ICAO when false
 // which routeApi service to use
 // routeApiUrl = "https://adsb.im/api/0/routeset";
 // routeApiUrl = "https://api.adsb.lol/api/0/routeset";

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -334,6 +334,8 @@ let planespottingAPI = false;
 
 // get flight route from routeApi service default setting (toggle via settings checkbox)
 let useRouteAPI = false;
+// show IATA airport codes instead of ICAO when using the route API
+let useIataAirportCodes = true;
 // which routeApi service to use
 let routeApiUrl = "https://adsb.im/api/0/routeset";
 // alternative: "https://api.adsb.lol/api/0/routeset";

--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -2930,22 +2930,23 @@ function routeDoLookup(currentTime) {
                         continue;
                     }
                     // let's log just a little bit of what's happening
+                    let codes = useIataAirportCodes ? route._airport_codes_iata : route.airport_codes;
                     if (debugRoute) {
                         var logText = `result for ${route.callsign}: `;
-                        if (route.airport_codes == 'unknown') {
+                        if (codes == 'unknown') {
                             logText += 'unknown to the API server';
                         } else if (route.plausible == false) {
-                            logText += `${route.airport_codes} considered implausible`;
+                            logText += `${codes} considered implausible`;
                         } else {
-                            logText += `adding ${route._airport_codes_iata}`;
+                            logText += `adding ${codes}`;
                         }
                         //console.log(logText);
                     }
-                    if (route.airport_codes != 'unknown') {
+                    if (codes != 'unknown') {
                         if (route.plausible == true) {
-                            g.route_cache[route.callsign] = route.airport_codes;
+                            g.route_cache[route.callsign] = codes;
                         } else {
-                            g.route_cache[route.callsign] = `?? ${route.airport_codes}`;
+                            g.route_cache[route.callsign] = `?? ${codes}`;
                         }
                     }
                 }

--- a/html/script.js
+++ b/html/script.js
@@ -1659,6 +1659,16 @@ jQuery('#selected_altitude_geom1')
                 }
             }
         });
+
+        new Toggle({
+            key: "useIataAirportCodes",
+            display: "Show IATA airport codes",
+            container: "#settingsRight",
+            init: useIataAirportCodes,
+            setState: function(state) {
+                useIataAirportCodes = state;
+            }
+        });
     } else {
         useRouteAPI = false;
     }


### PR DESCRIPTION
## Summary
- add `useIataAirportCodes` option so IATA/ICAO codes can be toggled
- expose new option in config and defaults
- hook up a UI toggle to control code format
- apply selected format in `routeDoLookup`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68581ded2388832396bdc452061336ba